### PR TITLE
feature/189 Self Assigning a Task

### DIFF
--- a/MOBILE/CommunityGardenApp/app/forum/ForumListScreen.tsx
+++ b/MOBILE/CommunityGardenApp/app/forum/ForumListScreen.tsx
@@ -110,7 +110,7 @@ export default function ForumListScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { padding: 8, flex: 1, backgroundColor: COLORS.background },
+  container: { paddingTop: -45, paddingHorizontal:14 ,flex: 1, backgroundColor: COLORS.background },
   communityButton: {
     backgroundColor: COLORS.primary,
     paddingHorizontal: 12,
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
   content: { fontSize: 14, marginVertical: 4 },
   author: { fontSize: 12, color: '#666' },
   emptyText: { textAlign: 'center', marginTop: 20 },
-  createButton: { backgroundColor: COLORS.primary, padding: 12, borderRadius: 8, alignItems: 'center', marginTop: 16 },
+  createButton: { backgroundColor: COLORS.primary, padding: 12, borderRadius: 8, alignItems: 'center', marginHorizontal: 16,marginBottom:30 },
   createButtonText: { color: 'white', fontWeight: 'bold' },
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
 }); 

--- a/MOBILE/CommunityGardenApp/app/forum/_layout.tsx
+++ b/MOBILE/CommunityGardenApp/app/forum/_layout.tsx
@@ -1,1 +1,5 @@
- 
+import { Stack } from 'expo-router';
+
+export default function ForumLayout() {
+  return <Stack />;
+}

--- a/MOBILE/CommunityGardenApp/app/tasks/task-detail.tsx
+++ b/MOBILE/CommunityGardenApp/app/tasks/task-detail.tsx
@@ -15,6 +15,7 @@ export default function TaskDetailScreen() {
   const [members, setMembers] = useState([]);
   const [selectedWorker, setSelectedWorker] = useState('');
   const [isManager, setIsManager] = useState(false);
+  const [isMember, setIsMember] = useState(false);
 
   useEffect(() => {
     fetchTask();
@@ -36,7 +37,9 @@ export default function TaskDetailScreen() {
       const accepted = memberRes.data.filter(m => m.status === 'ACCEPTED' && m.garden === gardenId);
       setMembers(accepted.filter(m => m.role === 'WORKER'));
       setIsManager(accepted.some(m => m.username === user.username && m.role === 'MANAGER'&& m.status ==='ACCEPTED'));
-      const workers = accepted.filter(m => m.role === 'WORKER');
+      setIsMember(accepted.some(m => m.username === user.username));
+      
+      
       
   
 
@@ -91,6 +94,22 @@ export default function TaskDetailScreen() {
     } catch (err) {
       console.error('Complete error:', err?.response?.data || err.message);
       Alert.alert('Error', 'Could not complete the task.');
+    }
+  };
+
+  const handleSelfAssign = async () => {
+    try {
+      await axios.post(
+        `${API_URL}/tasks/${task.id}/self-assign/`,
+        {},
+        { headers: { Authorization: `Token ${token}` } }
+      );
+      Alert.alert("Success", "You have been assigned to this task.");
+      // Optionally: refresh task state or navigate back
+      fetchTask(); 
+    } catch (err) {
+      console.error(err?.response?.data || err);
+      Alert.alert("Error", "Could not assign task to yourself.");
     }
   };
 
@@ -168,6 +187,15 @@ export default function TaskDetailScreen() {
           </TouchableOpacity>
           <TouchableOpacity style={styles.declineBtn} onPress={() => handleAction('decline')}>
             <Text style={styles.btnText}>Decline</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* self assign */}
+      {(task.status === 'PENDING' || task.status === 'DECLINED') && isMember && (
+        <View style={styles.actionRow}>
+          <TouchableOpacity style={styles.acceptBtn} onPress={handleSelfAssign}>
+            <Text style={styles.btnText}>Self Assign</Text>
           </TouchableOpacity>
         </View>
       )}

--- a/MOBILE/CommunityGardenApp/app/tasks/task-detail.tsx
+++ b/MOBILE/CommunityGardenApp/app/tasks/task-detail.tsx
@@ -192,7 +192,7 @@ export default function TaskDetailScreen() {
       )}
 
       {/* self assign */}
-      {(task.status === 'PENDING' || task.status === 'DECLINED') && isMember && (
+      {(task.status === 'PENDING' || task.status === 'DECLINED') && isMember && !isManager && task.assigned_to != user.id &&(
         <View style={styles.actionRow}>
           <TouchableOpacity style={styles.acceptBtn} onPress={handleSelfAssign}>
             <Text style={styles.btnText}>Self Assign</Text>

--- a/MOBILE/CommunityGardenApp/contexts/AuthContext.tsx
+++ b/MOBILE/CommunityGardenApp/contexts/AuthContext.tsx
@@ -53,6 +53,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const response = await axios.post(`${API_URL}/login/`, {
         username,
         password,
+        captcha,
       });
 
       const { token: newToken, user_id, username: responseUsername } = response.data;


### PR DESCRIPTION
## Feature Description
<!-- Provide a detailed description of the new feature -->
This feature enables garden members with the WORKER role to self-assign themselves to unassigned or declined tasks. It adds support on both the backend API and the mobile frontend to allow workers to claim a task without a manager needing to assign it manually.


## Implementation Details
<!-- Explain how the feature was implemented -->

On the backend, a new API endpoint POST /tasks/<task_id>/self-assign/ was added under the TaskViewSet using the @action decorator.
- The view ensures that the user is an accepted member of the task’s garden.
- It checks that the task is not already in progress or completed.
- Upon success, the current user is set as assigned_to and the status is set to IN_PROGRESS.

On the mobile frontend, in the task detail screen:
- If the current user is an accepted garden member and the task is PENDING or DECLINED, a “Self Assign” button is shown.
- Pressing the button calls the self-assign API endpoint and then refreshes the task state to reflect the update.

## Component
<!-- Mark the appropriate component(s) with an [x] -->
- [ ] Frontend
- [x] Backend
- [x] Mobile
- [ ] Other (please specify):

## Related Issue(s)
<!-- Link related issues using # syntax -->


## Screenshots/Videos
<!-- Add screenshots or videos that demonstrate the feature -->
<img width="375" alt="Screenshot 2025-05-14 at 02 17 41" src="https://github.com/user-attachments/assets/a28315e9-5762-4c39-bf86-75c3b2bc2264" />
<img width="359" alt="Screenshot 2025-05-14 at 02 17 46" src="https://github.com/user-attachments/assets/780da67a-1a7b-4908-aced-b259e2adfbd6" />
<img width="354" alt="Screenshot 2025-05-14 at 02 17 52" src="https://github.com/user-attachments/assets/981178c1-c8ea-4448-8fb0-3c5b6eeb9bdb" />

<img width="339" alt="Screenshot 2025-05-14 at 02 19 41" src="https://github.com/user-attachments/assets/19ede40f-2b6b-484a-a07b-176a23055898" />


## API Changes (if applicable)
<!-- Document any API changes made -->
POST /api/tasks/<task_id>/self-assign/
- Requires authentication.
- Assigns the task to the current user if eligible.
## New Dependencies (if applicable)
<!-- List any new dependencies added -->


## Testing Strategy
<!-- Describe how you tested the feature -->
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
- [ ] Other (please specify):

Manual testing was performed on iOS simulator by:
- Viewing a garden in which current logged in user is a worker of 
- Viewing a (declined or unassigned) pending task
- Tapping the “Self Assign” button
- Verifying task becomes assigned and enters IN_PROGRESS status

## Notes for Reviewers
- You should open and test the flow in an iOS emulator with a WORKER user who is part of a garden.
- Review both backend permission checks and frontend conditional rendering logic.