### PR TITLE
Fix: Prevent React Router from treating "settings" as userId parameter

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -46,7 +46,8 @@ const pages = [
 
 const settings = [
   { name: 'Profile', path: '/profile', icon: <PersonIcon /> },
-  { name: 'Settings', path: '/profile/settings', icon: <SettingsIcon /> },
+  // TODO: Implement Settings page
+  // { name: 'Settings', path: '/settings', icon: <SettingsIcon /> },
   { name: 'Logout', icon: <LogoutIcon />, action: 'logout' },
 ];
 

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -52,12 +52,24 @@ const Profile = () => {
   userId = userId ? userId.toString() : (user?.user_id?.toString() || '');
   const isOwnProfile = !userId || (user && user?.user_id?.toString() === userId);
 
+  useEffect(() => {
+    if (userId && isNaN(Number(userId))) {
+      toast.error('Invalid profile ID');
+      navigate('/profile');
+      return;
+    }
+  }, [userId, navigate]);
+
   // Fetch profile data
   useEffect(() => {
     const fetchProfileData = async () => {
       if (!token) {
         navigate('/auth/login');
         return;
+      }
+
+      if (userId && isNaN(Number(userId))) {
+        return; 
       }
 
       try {


### PR DESCRIPTION
React Router's /profile/:userId route was matching /profile/settings, causing the Profile component to treat "settings" as a user ID and make invalid API calls.