### PR TITLE
Show add task button only to accepted members

### DIFF
--- a/frontend/src/pages/garden/GardenDetail.jsx
+++ b/frontend/src/pages/garden/GardenDetail.jsx
@@ -71,6 +71,8 @@ const GardenDetail = () => {
     isPublic: false,
   });
 
+  const isAccepted = isMember && userMembership?.status === 'ACCEPTED';
+
   const { gardenId } = useParams();
   const navigate = useNavigate();
 
@@ -776,7 +778,7 @@ const GardenDetail = () => {
               <Typography variant="h6" sx={{ color: theme.palette.primary.main }}>
                 {t('gardens.gardenTasks')}
               </Typography>
-              {isMember && (
+              {isMember && isAccepted && (
                 <Button
                   variant="contained"
                   onClick={() => {


### PR DESCRIPTION
Restrict the visibility of the add task button to members with an accepted status.

Related issue: #314 