### PR TITLE
Swagger API Documentation

### DIFF
--- a/gardenPlannerBackend/core/settings.py
+++ b/gardenPlannerBackend/core/settings.py
@@ -49,6 +49,7 @@ INSTALLED_APPS = [
     'rest_framework',
     'rest_framework.authtoken',
     'corsheaders',
+    'drf_yasg',
     
     # Local apps
     'gardenplanner.apps.garden',

--- a/gardenPlannerBackend/core/urls.py
+++ b/gardenPlannerBackend/core/urls.py
@@ -28,6 +28,26 @@ urlpatterns = [
     path('api/weather/', WeatherDataView.as_view(), name='weather'),
 ]
 
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="Garden Planner API",
+      default_version='v1',
+      description="API documentation for Garden Planner",
+   ),
+   public=True,
+   permission_classes=(permissions.AllowAny,),
+)
+
+urlpatterns += [
+   path('api/swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+   path('api/swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+   path('api/redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+]
+
 # Serve media files in development
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/gardenPlannerBackend/requirements.txt
+++ b/gardenPlannerBackend/requirements.txt
@@ -12,3 +12,4 @@ requests==2.32.3
 django-cors-headers==4.7.0
 psycopg2-binary==2.9.9
 firebase-admin==6.5.0
+drf-yasg


### PR DESCRIPTION
Added automatic API documentation to the app by integrating the `drf-yasg` library. This enables interactive Swagger and ReDoc documentation for the API which are available at:

For Development:
`http://localhost:8000/api/swagger`
`http://localhost:8000/api/redoc`

For Production:
`https://communitygarden.app/api/swagger`
`https://communitygarden.app/api/redoc`

Note: Basic authentication that Swagger provides is as functional as login process.