### PR TITLE
Reverse Proxy Configurations for Swagger and Django Admin

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,6 +28,13 @@ server {
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
+    # Serve frontend files
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+
     # API proxy to backend
     location /api/ {
         proxy_pass http://backend:8000/api/;
@@ -37,10 +44,36 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Serve frontend files
-    location / {
-        root /usr/share/nginx/html;
-        index index.html;
-        try_files $uri $uri/ /index.html;
+    # Django admin proxy
+    location /admin/ {
+        proxy_pass http://backend:8000/admin/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Swagger proxy
+    location /swagger/ {
+        proxy_pass http://backend:8000/swagger/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Redoc proxy
+    location /redoc/ {
+        proxy_pass http://backend:8000/redoc/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Static files for Django admin/swagger assets
+    location /static/ {
+        proxy_pass http://backend:8000/static/;
+        proxy_set_header Host $host;
     }
 }

--- a/gardenPlannerBackend/core/urls.py
+++ b/gardenPlannerBackend/core/urls.py
@@ -43,9 +43,9 @@ schema_view = get_schema_view(
 )
 
 urlpatterns += [
-   path('api/swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-   path('api/swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-   path('api/redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+   path('swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+   path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+   path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
 ]
 
 # Serve media files in development


### PR DESCRIPTION
### Summary
This PR implements necessary updates to expose Swagger and Django Admin to the web. `/swagger` and `/admin` endpoints of the backend are now reverse-proxied in Nginx. These endpoints should be reachable and functional at:

- `http://localhost/swagger` and `http://localhost/admin` for local deployment
- `https://communitygarden.app/swagger` and `https://communitygarden.app/admin` for production (after the production update)



### Testing
Assuming you don't have an HTTPS setup locally, you should update `nginx.conf` file to:
```
server {
    listen 80;
    server_name localhost;

    location / {
        root /usr/share/nginx/html;
        index index.html;
        try_files $uri $uri/ /index.html;
    }
    
    location /api/ {
        proxy_pass http://backend:8000/api/;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }

    # Django admin proxy
    location /admin/ {
        proxy_pass http://backend:8000/admin/;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }

    # Swagger proxy
    location /swagger/ {
        proxy_pass http://backend:8000/swagger/;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }

    # Redoc proxy
    location /redoc/ {
        proxy_pass http://backend:8000/redoc/;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }

    # Static files for Django admin/swagger assets
    location /static/ {
        proxy_pass http://backend:8000/static/;
        proxy_set_header Host $host;
    }

}
```
to be able to test if these pages are reachable directly through frontend with URLs  `http://localhost/swagger` and `http://localhost/admin` 