### PR TITLE
google maps API integrated

### DIFF
--- a/MOBILE/CommunityGardenApp/locales/en/translation.json
+++ b/MOBILE/CommunityGardenApp/locales/en/translation.json
@@ -145,7 +145,12 @@
       "statuses": {
         "ACCEPTED": "Accepted",
         "PENDING": "Pending"
-      }
+      },
+      "showDirections": "Show Directions",
+      "noLocation": "Garden location is not available.",
+      "mapsError": "Could not open maps application. Please check if you have a maps app installed.",
+      "joinRequestSent": "Join request sent! Waiting for manager approval.",
+      "joinRequestError": "Could not send join request"
     },
     "create": {
       "title": "Create New Garden",

--- a/MOBILE/CommunityGardenApp/locales/tr/translation.json
+++ b/MOBILE/CommunityGardenApp/locales/tr/translation.json
@@ -145,7 +145,12 @@
       "statuses": {
         "ACCEPTED": "Kabul Edildi",
         "PENDING": "Beklemede"
-      }
+      },
+      "showDirections": "Yol Tarifi Göster",
+      "noLocation": "Bahçe konumu mevcut değil.",
+      "mapsError": "Harita uygulaması açılamadı. Lütfen bir harita uygulaması yüklü olduğundan emin olun.",
+      "joinRequestSent": "Katılım isteği gönderildi! Yönetici onayı bekleniyor.",
+      "joinRequestError": "Katılım isteği gönderilemedi"
     },
     "create": {
       "title": "Yeni Bahçe Oluştur",


### PR DESCRIPTION
# Feature/Show Directions to Garden

## Feature Description

**FR 1.7 Enhancement**: Users can navigate to gardens directly from the garden detail page using their preferred maps application.

## Implementation Details

The mobile app adds a "Show Directions" button on the garden detail page that opens Google Maps (or the native maps app) with turn-by-turn navigation to the garden's location. The implementation uses platform-specific URL schemes to open native apps when available, with a fallback to the web version.

### **Core Features**

- **Show Directions Button**: Button with navigation icon on the garden detail page
- **Platform-Specific Navigation**: 
  - iOS: Opens Google Maps app (`comgooglemaps://`) or falls back to web
- **Conditional Display**: Button only appears when the garden has a valid location
- **Smart Fallback**: If native app isn't installed, automatically opens web version
- **Error Handling**: User-friendly error messages if maps cannot be opened
- **Location Validation**: Checks for valid location before showing button

### **Technical Implementation**

- Uses `expo-linking` for deep linking to maps applications
- Platform detection using React Native's `Platform` API
- URL encoding for special characters in location strings
- Graceful error handling with user feedback

## Component

- [ ] Frontend
- [ ] Backend
- [x] Mobile
- [ ] Other (please specify):


## Testing Strategy

- [x] Manual testing - Button visibility, Native app opening, Web fallback, Error handling
- [ ] Integration tests
- [ ] Unit tests

### **Files Modified/Added**

#### **Updated Files:**

- `app/garden/[id].tsx` - Added "Show Directions" button, `handleShowDirections` function, platform-specific URL handling, and conditional rendering logic


### **User Experience**

- Button appears automatically when a garden has a location set
- Tapping the button opens the native maps app (if installed) or web version
- Navigation starts immediately with the garden as the destination


### **Screenshots**
<img width="372" height="754" alt="Screenshot 2025-12-15 at 01 21 19" src="https://github.com/user-attachments/assets/6a3cf5e3-7c0f-4ccb-bbf0-60594780cc7b" />

